### PR TITLE
Fixed response-short-circuit by request filter

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -128,7 +128,7 @@ const requestWithFilters = (params, filters) => {
 
     const requestFilterPromise = filters.reduce((promise, filter) => {
         return promise.then(params => {
-            if (typeof params === ServiceClient.Response) {
+            if (params instanceof ServiceClient.Response) {
                 return params;
             }
             const filtered = filter.request ? filter.request(params) : params;
@@ -144,7 +144,7 @@ const requestWithFilters = (params, filters) => {
     return requestFilterPromise
     .catch((err) => wrapFailedError(ServiceClient.REQUEST_FILTER_FAILED, err))
     .then((paramsOrResponse) =>
-        (typeof paramsOrResponse === ServiceClient.Response) ? paramsOrResponse : request(paramsOrResponse)
+        (paramsOrResponse instanceof ServiceClient.Response) ? paramsOrResponse : request(paramsOrResponse)
     )
     .then(
         (rawResponse) => {

--- a/test/client.js
+++ b/test/client.js
@@ -196,7 +196,7 @@ describe('ServiceClient', () => {
             foo: 'bar'
         };
         clientOptions.filters = [{
-            response() {
+            request() {
                 return new ServiceClient.Response(404, headers, body);
             }
         }];

--- a/test/request.js
+++ b/test/request.js
@@ -25,16 +25,22 @@ describe('request', () => {
     });
 
     it('should call https if protocol is not specified', () => {
+        const requestStub = new RequestStub();
+        httpsStub.request.returns(requestStub);
         request();
         assert.equal(httpsStub.request.callCount, 1);
     });
 
     it('should allow to call http if it is specified as protocol', () => {
+        const requestStub = new RequestStub();
+        httpStub.request.returns(requestStub);
         request({ protocol: 'http:' });
         assert.equal(httpStub.request.callCount, 1);
     });
 
     it('should return a promise', () => {
+        const requestStub = new RequestStub();
+        httpsStub.request.returns(requestStub);
         assert(typeof request().then, 'function');
     });
 


### PR DESCRIPTION
Response short-circuit by request filter was not working properly. Its test was using a response filter.

Also fixed `UnhandledPromiseRejectionWarning`s in unit tests.