### PR TITLE
Inflate gzipped response body

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -1,5 +1,6 @@
 const http = require('http');
 const https = require('https');
+const zlib = require('zlib');
 
 module.exports = (options) => {
     options = Object.assign({
@@ -7,12 +8,21 @@ module.exports = (options) => {
     }, options);
     const httpModule = options.protocol === 'https:' ? https : http;
     return new Promise((resolve, reject) => {
-        const chunks = [];
         const request = httpModule.request(options, (response) => {
-            response.on('data', (chunk) => {
+            let bodyStream;
+            const chunks = [];
+            const encoding = response.headers && response.headers['content-encoding'];
+            if (encoding === 'gzip' || encoding === 'deflate') {
+                response.on('error', reject);
+                bodyStream = response.pipe(zlib.createUnzip());
+            } else {
+                bodyStream = response;
+            }
+            bodyStream.on('error', reject);
+            bodyStream.on('data', (chunk) => {
                 chunks.push(chunk);
             });
-            response.on('end', () => {
+            bodyStream.on('end', () => {
                 response.body = Buffer.concat(chunks).toString('utf8');
                 resolve(response);
             });


### PR DESCRIPTION
Inflate response body when `content-encoding` header is `gzip` or `deflate`. This condition is based on [tailor's implementation](https://github.com/zalando/tailor/blob/fba76d975c060a6ee7c925eb1de6d44aff43b645/lib/fragment.js#L148).

Also added error handling for response stream errors.

Fixes #10