### PR TITLE
Stop assuming JSON content type if response body is empty

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -73,8 +73,8 @@ const CircuitBreaker = require('circuit-breaker-js');
  * @returns {ServiceClient.Response}
  */
 const decodeResponse = (response) => {
-    const contentType = response.headers['content-type'] || 'application/json';
-    if (response.statusCode !== 204 && contentType.startsWith('application/json') && typeof response.body !== 'object') {
+    const contentType = response.headers['content-type'] || (response.body ? 'application/json' : '');
+    if (contentType.startsWith('application/json') && typeof response.body !== 'object') {
         try {
             response.body = JSON.parse(response.body);
         } catch (error) {


### PR DESCRIPTION
Fixes #12.

Also added `done` callbacks to tests with `return promise.catch((err) => { /* assertion */ })` because they won't fail if the promises resolve.