### PR TITLE
Default request params. Fixes #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,13 @@ The following is a minimal example of using `perron` to call a web service:
 const ServiceClient = require('perron');
 
 // A separate instance of `perron` is required per host
-const catWatch = new ServiceClient({
-    hostname: 'catwatch.opensource.zalan.do'
-});
+const catWatch = new ServiceClient('https://catwatch.opensource.zalan.do');
 
 catWatch.request({
-    path: '/projects?limit=10'
+    pathname: '/projects',
+    query: {
+        limit: 10
+    }
 }).then(data => console.log(data));
 ```
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,4 +1,5 @@
 const request = require('./request');
+const url = require('url');
 const CircuitBreaker = require('circuit-breaker-js');
 
 /**
@@ -159,6 +160,8 @@ const requestWithFilters = (params, filters) => {
 
 const DEFAULT_REQUEST_TIMEOUT = 2000;
 
+/** @typedef string URL */
+
 /**
  * @constructor
  * @property {CircuitBreaker} breaker
@@ -167,13 +170,34 @@ const DEFAULT_REQUEST_TIMEOUT = 2000;
 class ServiceClient {
 
     /**
-     * @param {ServiceClientOptions} options
+     * @param {ServiceClientOptions|URL} optionsOrUrl
      */
-    constructor(options) {
+    constructor(optionsOrUrl) {
+        let options;
+        if (typeof optionsOrUrl === 'string') {
+            const parsed = url.parse(optionsOrUrl, true);
+            const defaultRequestOptions = {};
+            ['port', 'protocol', 'query', 'pathname'].forEach((option) => {
+                if (parsed.hasOwnProperty(option)) {
+                    defaultRequestOptions[option] = parsed[option];
+                }
+            });
+            options = {
+                hostname: parsed.hostname,
+                defaultRequestOptions
+            };
+        } else {
+            options = optionsOrUrl;
+        }
+
         this.options = Object.assign({
             filters: ServiceClient.DEFAULT_FILTERS,
             circuitBreaker: {}
         }, options);
+
+        if (!this.options.hostname) {
+            throw new Error('Please provide a `hostname` for this client');
+        }
 
         this.options.defaultRequestOptions = Object.assign({
             protocol: 'https:',
@@ -193,10 +217,6 @@ class ServiceClient {
         } else {
             const noop = () => {};
             this.breaker = { run(command) { command(noop, noop); } };
-        }
-
-        if (!this.options.hostname) {
-            throw new Error('Please provide a `hostname` for this client');
         }
     }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -177,7 +177,7 @@ class ServiceClient {
 
         this.options.defaultRequestOptions = Object.assign({
             protocol: 'https:',
-            path: '/',
+            pathname: '/',
             timeout: DEFAULT_REQUEST_TIMEOUT
         }, this.options.defaultRequestOptions);
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -175,6 +175,12 @@ class ServiceClient {
             circuitBreaker: {}
         }, options);
 
+        this.options.defaultRequestOptions = Object.assign({
+            protocol: 'https:',
+            path: '/',
+            timeout: DEFAULT_REQUEST_TIMEOUT
+        }, this.options.defaultRequestOptions);
+
         if (this.options.circuitBreaker) {
             const breakerOptions = Object.assign({
                 windowDuration: 10000,
@@ -196,19 +202,14 @@ class ServiceClient {
 
     /**
      * Perform a request to the service using given `params`.
-     * @param {ServiceClientRequestParams=} params
+     * @param {ServiceClientRequestParams=} userParams
      * @returns {Promise.<ServiceClientResponse>}
      */
-    request(params) {
-        params = Object.assign({
-            protocol: 'https:',
-            path: '/',
-            timeout: DEFAULT_REQUEST_TIMEOUT
-        }, params, {
-            hostname: this.options.hostname
-        });
+    request(userParams) {
+        const params = Object.assign({}, this.options.defaultRequestOptions, userParams);
 
-        params.port = params.port || (params.protocol ? 443 : 80);
+        params.hostname = this.options.hostname;
+        params.port = params.port || (params.protocol === 'https:' ? 443 : 80);
 
         params.headers = Object.assign({
             accept: 'application/json'

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,11 +1,21 @@
 const http = require('http');
 const https = require('https');
 const zlib = require('zlib');
+const querystring = require('querystring');
 
 module.exports = (options) => {
     options = Object.assign({
         protocol: 'https:'
     }, options);
+
+    if ('pathname' in options && !('path' in options)) {
+        if ('query' in options) {
+            options.path = `${options.pathname}?${querystring.stringify(options.query)}`;
+        } else {
+            options.path = options.pathname;
+        }
+    }
+
     const httpModule = options.protocol === 'https:' ? https : http;
     return new Promise((resolve, reject) => {
         const request = httpModule.request(options, (response) => {

--- a/test/client.js
+++ b/test/client.js
@@ -277,7 +277,7 @@ describe('ServiceClient', () => {
     });
 
     describe('request params', () => {
-        const defaultRequestParams = {
+        const expectedDefaultRequestOptions = {
             hostname: 'catwatch.opensource.zalan.do',
             protocol: 'https:',
             port: 443,
@@ -290,7 +290,7 @@ describe('ServiceClient', () => {
         it('should pass reasonable request params by default', (done) => {
             const client = new ServiceClient(clientOptions);
             return client.request().then(() => {
-                assert.deepStrictEqual(requestStub.firstCall.args[0], defaultRequestParams);
+                assert.deepStrictEqual(requestStub.firstCall.args[0], expectedDefaultRequestOptions);
                 done();
             });
         });
@@ -299,7 +299,7 @@ describe('ServiceClient', () => {
             return client.request({foo: 'bar'}).then(() => {
                 assert.deepStrictEqual(
                     requestStub.firstCall.args[0],
-                    Object.assign({foo: 'bar'}, defaultRequestParams)
+                    Object.assign({foo: 'bar'}, expectedDefaultRequestOptions)
                 );
                 done();
             });
@@ -309,7 +309,35 @@ describe('ServiceClient', () => {
             return client.request({path: '/foo'}).then(() => {
                 assert.deepStrictEqual(
                     requestStub.firstCall.args[0],
-                    Object.assign({}, defaultRequestParams, {path: '/foo'})
+                    Object.assign({}, expectedDefaultRequestOptions, {path: '/foo'})
+                );
+                done();
+            });
+        });
+        it('should allow to specify default params of the request', (done) => {
+            const userDefaultRequestOptions = {
+                path: '/foo',
+                protocol: 'http:'
+            };
+            const client = new ServiceClient(Object.assign({}, clientOptions, {
+                defaultRequestOptions: userDefaultRequestOptions
+            }));
+            return client.request().then(() => {
+                assert.deepStrictEqual(
+                    requestStub.firstCall.args[0],
+                    Object.assign({}, expectedDefaultRequestOptions, userDefaultRequestOptions, {port: 80})
+                );
+                done();
+            });
+        });
+        it('should not allow to override hostname', (done) => {
+            const client = new ServiceClient(Object.assign({}, clientOptions, {
+                defaultRequestOptions: {hostname: 'zalando.de'}
+            }));
+            return client.request().then(() => {
+                assert.deepStrictEqual(
+                    requestStub.firstCall.args[0],
+                    Object.assign({}, expectedDefaultRequestOptions)
                 );
                 done();
             });

--- a/test/client.js
+++ b/test/client.js
@@ -314,10 +314,21 @@ describe('ServiceClient', () => {
                 done();
             });
         });
+        it('should allow to specify query params of the request', (done) => {
+            const client = new ServiceClient(clientOptions);
+            return client.request({pathname: '/foo', query: {param: 1}}).then(() => {
+                assert.deepStrictEqual(
+                    requestStub.firstCall.args[0],
+                    Object.assign({}, expectedDefaultRequestOptions, {pathname: '/foo', query: {param: 1}})
+                );
+                done();
+            });
+        });
         it('should allow to specify default params of the request', (done) => {
             const userDefaultRequestOptions = {
                 pathname: '/foo',
-                protocol: 'http:'
+                protocol: 'http:',
+                query: { param: 42 }
             };
             const client = new ServiceClient(Object.assign({}, clientOptions, {
                 defaultRequestOptions: userDefaultRequestOptions

--- a/test/client.js
+++ b/test/client.js
@@ -284,7 +284,7 @@ describe('ServiceClient', () => {
             headers: {
                 accept: 'application/json'
             },
-            path: '/',
+            pathname: '/',
             timeout: 2000
         };
         it('should pass reasonable request params by default', (done) => {
@@ -306,17 +306,17 @@ describe('ServiceClient', () => {
         });
         it('should allow to override params of the request', (done) => {
             const client = new ServiceClient(clientOptions);
-            return client.request({path: '/foo'}).then(() => {
+            return client.request({pathname: '/foo'}).then(() => {
                 assert.deepStrictEqual(
                     requestStub.firstCall.args[0],
-                    Object.assign({}, expectedDefaultRequestOptions, {path: '/foo'})
+                    Object.assign({}, expectedDefaultRequestOptions, {pathname: '/foo'})
                 );
                 done();
             });
         });
         it('should allow to specify default params of the request', (done) => {
             const userDefaultRequestOptions = {
-                path: '/foo',
+                pathname: '/foo',
                 protocol: 'http:'
             };
             const client = new ServiceClient(Object.assign({}, clientOptions, {

--- a/test/client.js
+++ b/test/client.js
@@ -353,5 +353,22 @@ describe('ServiceClient', () => {
                 done();
             });
         });
+        it('should support taking hostname and default params from a URL instead of an object', () => {
+            const client = new ServiceClient('http://localhost:9999/foo?param=42');
+            return client.request().then(() => {
+                assert.deepEqual(
+                    requestStub.firstCall.args[0],
+                    Object.assign({}, expectedDefaultRequestOptions, {
+                        port: 9999,
+                        hostname: 'localhost',
+                        pathname: '/foo',
+                        protocol: 'http:',
+                        query: {
+                            param: '42'
+                        }
+                    })
+                );
+            });
+        });
     });
 });

--- a/test/request.js
+++ b/test/request.js
@@ -51,6 +51,27 @@ describe('request', () => {
         assert.equal(httpStub.request.callCount, 1);
     });
 
+    it('should use pathname as path if none specified', () => {
+        const requestStub = new RequestStub();
+        httpsStub.request.returns(requestStub);
+        request({pathname: '/foo'});
+        assert.equal(httpsStub.request.firstCall.args[0].path, '/foo');
+    });
+
+    it('should prefer fully resolved path even if pathname is specified', () => {
+        const requestStub = new RequestStub();
+        httpsStub.request.returns(requestStub);
+        request({pathname: '/foo', path: '/bar'});
+        assert.equal(httpsStub.request.firstCall.args[0].path, '/bar');
+    });
+
+    it('should allow to specify query params as an object', () => {
+        const requestStub = new RequestStub();
+        httpsStub.request.returns(requestStub);
+        request({query: {foo: 'bar', buz: 42}, pathname: '/'});
+        assert.equal(httpsStub.request.firstCall.args[0].path, '/?foo=bar&buz=42');
+    });
+
     it('should return a promise', () => {
         const requestStub = new RequestStub();
         httpsStub.request.returns(requestStub);


### PR DESCRIPTION
This PR improves library DX by removing necessity to manually specify URL parts or to manually serialize query strings.

All changes are expected to be completely backwards compatible.