### PR TITLE
Reject timed out requests

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -20,6 +20,7 @@ const CircuitBreaker = require('circuit-breaker-js');
  *  protocol?: string,
  *  service: string,
  *  filters?: Array.<ServiceClient~requestFilter>,
+ *  dropRequestAfter?: number,
  *  circuitBreaker?: (false|{
  *      windowDuration?: number,
  *      numBuckets?: number,

--- a/lib/request.js
+++ b/lib/request.js
@@ -20,6 +20,7 @@ module.exports = (options) => {
 
     const httpModule = options.protocol === 'https:' ? https : http;
     return new Promise((resolve, reject) => {
+        let hasRequestEnded = false;
         const request = httpModule.request(options, (response) => {
             let bodyStream;
             const chunks = [];
@@ -36,10 +37,23 @@ module.exports = (options) => {
             });
             bodyStream.on('end', () => {
                 response.body = Buffer.concat(chunks).toString('utf8');
+                hasRequestEnded = true;
                 resolve(response);
             });
         });
         request.on('error', reject);
+        request.on('timeout', () => {
+            request.abort();
+            reject(new Error('socket timeout'));
+        });
+        if (options.dropRequestAfter) {
+            setTimeout(() => {
+                if (!hasRequestEnded) {
+                    request.abort();
+                    reject(new Error('request timeout'));
+                }
+            }, options.dropRequestAfter);
+        }
         if (options.body) {
             request.write(options.body);
         }


### PR DESCRIPTION
Adding the following options:

- `timeout`: Reject the request when the socket has been inactive for `timeout` ms.
- `dropRequestAfter`: Reject the request when the request doesn't finish in `dropRequestAfter` ms.

Fixes #19.