### PR TITLE
Add timing option to measure network timings

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -20,7 +20,6 @@ const CircuitBreaker = require('circuit-breaker-js');
  *  protocol?: string,
  *  service: string,
  *  filters?: Array.<ServiceClient~requestFilter>,
- *  dropRequestAfter?: number,
  *  timing?: boolean,
  *  circuitBreaker?: (false|{
  *      windowDuration?: number,
@@ -28,6 +27,7 @@ const CircuitBreaker = require('circuit-breaker-js');
  *      timeoutDuration?: number,
  *      errorThreshold?: number,
  *      volumeThreshold?: number })
+ *  defaultRequestOptions?: ServiceClientRequestParams
  * }} ServiceClientOptions
  */
 
@@ -39,6 +39,8 @@ const CircuitBreaker = require('circuit-breaker-js');
  *  port?: number,
  *  path?: string,
  *  body?: string
+ *  timeout?: number,
+ *  dropRequestAfter?: number,
  * }} ServiceClientRequestParams
  */
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -95,7 +95,6 @@ const decodeResponse = (response) => {
         response.headers,
         response.body
     );
-    clientResponse.timingStart = response.timingStart;
     clientResponse.timings = response.timings;
     clientResponse.timingPhases = response.timingPhases;
     return clientResponse;

--- a/lib/client.js
+++ b/lib/client.js
@@ -21,6 +21,7 @@ const CircuitBreaker = require('circuit-breaker-js');
  *  service: string,
  *  filters?: Array.<ServiceClient~requestFilter>,
  *  dropRequestAfter?: number,
+ *  timing?: boolean,
  *  circuitBreaker?: (false|{
  *      windowDuration?: number,
  *      numBuckets?: number,
@@ -87,11 +88,15 @@ const decodeResponse = (response) => {
             );
         }
     }
-    return new ServiceClient.Response(
+    const clientResponse = new ServiceClient.Response(
         response.statusCode,
         response.headers,
         response.body
     );
+    clientResponse.timingStart = response.timingStart;
+    clientResponse.timings = response.timings;
+    clientResponse.timingPhases = response.timingPhases;
+    return clientResponse;
 };
 
 /**

--- a/lib/request.js
+++ b/lib/request.js
@@ -21,7 +21,18 @@ module.exports = (options) => {
     const httpModule = options.protocol === 'https:' ? https : http;
     return new Promise((resolve, reject) => {
         let hasRequestEnded = false;
+        const startTime = Date.now();
+        const timings = {};
         const request = httpModule.request(options, (response) => {
+            if (options.timing) {
+                if (timings.lookup === undefined) {
+                    timings.lookup = timings.socket;
+                }
+                if (timings.connect === undefined) {
+                    timings.connect = timings.socket;
+                }
+                timings.response = Date.now() - startTime;
+            }
             let bodyStream;
             const chunks = [];
             const encoding = response.headers && response.headers['content-encoding'];
@@ -38,9 +49,44 @@ module.exports = (options) => {
             bodyStream.on('end', () => {
                 response.body = Buffer.concat(chunks).toString('utf8');
                 hasRequestEnded = true;
+                if (options.timing) {
+                    timings.end = Date.now() - startTime;
+                    response.timingStart = startTime;
+                    response.timings = timings;
+                    response.timingPhases = {
+                        wait: timings.socket,
+                        dns: timings.lookup - timings.socket,
+                        tcp: timings.connect - timings.lookup,
+                        firstByte: timings.response - timings.connect,
+                        download: timings.end - timings.response,
+                        total: timings.end
+                    };
+                }
                 resolve(response);
             });
         });
+        if (options.timing) {
+            request.once('socket', (socket) => {
+                timings.socket = Date.now() - startTime;
+                if (socket.connecting) {
+                    const onLookUp = () => {
+                        timings.lookup = Date.now() - startTime;
+                    };
+                    const onConnect = () => {
+                        timings.connect = Date.now() - startTime;
+                    };
+                    socket.once('lookup', onLookUp);
+                    socket.once('connect', onConnect);
+                    request.once('error', () => {
+                        socket.removeListener('lookup', onLookUp);
+                        socket.removeListener('connect', onConnect);
+                    });
+                } else {
+                    timings.lookup = timings.socket;
+                    timings.connect = timings.socket;
+                }
+            });
+        }
         request.on('error', reject);
         request.on('timeout', () => {
             request.abort();

--- a/lib/request.js
+++ b/lib/request.js
@@ -5,6 +5,11 @@ const https = require('https');
 const zlib = require('zlib');
 const querystring = require('querystring');
 
+const getInterval = (time) => {
+    const diff = process.hrtime(time);
+    return Math.round((diff[0] * 1000) + (diff[1] / 1000000));
+};
+
 module.exports = (options) => {
     options = Object.assign({
         protocol: 'https:'
@@ -24,7 +29,7 @@ module.exports = (options) => {
         let startTime;
         let timings;
         if (options.timing) {
-            startTime = Date.now();
+            startTime = process.hrtime();
             timings = {};
         }
         const request = httpModule.request(options, (response) => {
@@ -35,7 +40,7 @@ module.exports = (options) => {
                 if (timings.connect === undefined) {
                     timings.connect = timings.socket;
                 }
-                timings.response = Date.now() - startTime;
+                timings.response = getInterval(startTime);
             }
             let bodyStream;
             const chunks = [];
@@ -54,8 +59,7 @@ module.exports = (options) => {
                 response.body = Buffer.concat(chunks).toString('utf8');
                 hasRequestEnded = true;
                 if (options.timing) {
-                    timings.end = Date.now() - startTime;
-                    response.timingStart = startTime;
+                    timings.end = getInterval(startTime);
                     response.timings = timings;
                     response.timingPhases = {
                         wait: timings.socket,
@@ -71,13 +75,13 @@ module.exports = (options) => {
         });
         if (options.timing) {
             request.once('socket', (socket) => {
-                timings.socket = Date.now() - startTime;
+                timings.socket = getInterval(startTime);
                 if (socket.connecting) {
                     const onLookUp = () => {
-                        timings.lookup = Date.now() - startTime;
+                        timings.lookup = getInterval(startTime);
                     };
                     const onConnect = () => {
-                        timings.connect = Date.now() - startTime;
+                        timings.connect = getInterval(startTime);
                     };
                     socket.once('lookup', onLookUp);
                     socket.once('connect', onConnect);

--- a/lib/request.js
+++ b/lib/request.js
@@ -21,8 +21,12 @@ module.exports = (options) => {
     const httpModule = options.protocol === 'https:' ? https : http;
     return new Promise((resolve, reject) => {
         let hasRequestEnded = false;
-        const startTime = Date.now();
-        const timings = {};
+        let startTime;
+        let timings;
+        if (options.timing) {
+            startTime = Date.now();
+            timings = {};
+        }
         const request = httpModule.request(options, (response) => {
             if (options.timing) {
                 if (timings.lookup === undefined) {

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -10,6 +10,12 @@ class ResponseStub extends EventEmitter {}
 class RequestStub extends EventEmitter {
     end() {}
 }
+class SocketStub extends EventEmitter {
+    constructor(connecting) {
+        super();
+        this.connecting = connecting;
+    }
+}
 class BufferStream extends stream.Readable {
     constructor(buffer) {
         super();
@@ -30,13 +36,13 @@ describe('request', () => {
 
     const httpStub = {};
     const httpsStub = {};
-    let clock;
 
     let request = proxyquire('../lib/request', {
         http: httpStub,
         https: httpsStub
     });
     let requestStub;
+    let clock;
 
     beforeEach(() => {
         httpStub.request = sinon.stub();
@@ -44,6 +50,10 @@ describe('request', () => {
         requestStub = new RequestStub();
         httpsStub.request.returns(requestStub);
         clock = sinon.useFakeTimers();
+    });
+
+    afterEach(() => {
+        clock.restore();
     });
 
     afterEach(() => {
@@ -234,6 +244,72 @@ describe('request', () => {
             done();
         }).catch(done);
         clock.tick(500);
+    });
+
+    it('should record timings for non-keep-alive connection', (done) => {
+        request({ timing: true }).then(response => {
+            assert.equal(response.timingStart, Date.now() - 150);
+            assert.deepEqual(response.timings, {
+                socket: 10,
+                lookup: 30,
+                connect: 60,
+                response: 100,
+                end: 150
+            });
+            assert.deepEqual(response.timingPhases, {
+                wait: 10,
+                dns: 20,
+                tcp: 30,
+                firstByte: 40,
+                download: 50,
+                total: 150
+            });
+            done();
+        }).catch(done);
+        const socketStub = new SocketStub(true);
+        clock.tick(10);
+        requestStub.emit('socket', socketStub);
+        clock.tick(20);
+        socketStub.emit('lookup');
+        clock.tick(30);
+        socketStub.emit('connect');
+        clock.tick(40);
+        const responseStub = new ResponseStub();
+        httpsStub.request.firstCall.args[1](responseStub);
+        clock.tick(50);
+        responseStub.emit('data', Buffer.from('hello'));
+        responseStub.emit('end');
+    });
+
+    it('should record timings for keep-alive connection', (done) => {
+        request({ timing: true }).then(response => {
+            assert.equal(response.timingStart, Date.now() - 60);
+            assert.deepEqual(response.timings, {
+                socket: 10,
+                lookup: 10,
+                connect: 10,
+                response: 30,
+                end: 60
+            });
+            assert.deepEqual(response.timingPhases, {
+                wait: 10,
+                dns: 0,
+                tcp: 0,
+                firstByte: 20,
+                download: 30,
+                total: 60
+            });
+            done();
+        }).catch(done);
+        const socketStub = new SocketStub(false);
+        clock.tick(10);
+        requestStub.emit('socket', socketStub);
+        clock.tick(20);
+        const responseStub = new ResponseStub();
+        httpsStub.request.firstCall.args[1](responseStub);
+        clock.tick(30);
+        responseStub.emit('data', Buffer.from('hello'));
+        responseStub.emit('end');
     });
 
 });

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -248,7 +248,6 @@ describe('request', () => {
 
     it('should record timings for non-keep-alive connection', (done) => {
         request({ timing: true }).then(response => {
-            assert.equal(response.timingStart, Date.now() - 150);
             assert.deepEqual(response.timings, {
                 socket: 10,
                 lookup: 30,
@@ -283,7 +282,6 @@ describe('request', () => {
 
     it('should record timings for keep-alive connection', (done) => {
         request({ timing: true }).then(response => {
-            assert.equal(response.timingStart, Date.now() - 60);
             assert.deepEqual(response.timings, {
                 socket: 10,
                 lookup: 10,


### PR DESCRIPTION
Borrowing `time` option of [request/request](https://github.com/request/request).

If you specify `timing: true` option, it adds the following properties to response object:

- `timings`
- `timingPhases`

Because perron doesn't expose `request` object, users cannot measure detailed timings. Does it make sense to add it to perron?

As a perron's user, I'd like to have this for cases when API latency metrics look very different on the client side and the service side.