### PR TITLE
Attach the request options to the response

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -49,7 +49,8 @@ const CircuitBreaker = require('circuit-breaker-js');
  *  headers: ServiceClientHeaders,
  *  method: string,
  *  statusCode: number,
- *  body: any
+ *  body: any,
+ *  request: ?ServiceClientRequestParams
  * }} ServiceClientResponse
  */
 
@@ -75,7 +76,7 @@ const CircuitBreaker = require('circuit-breaker-js');
 
 /**
  *
- * @param {{ headers: ServiceClientHeaders, statusCode: number, body: string }} response
+ * @param {{ headers: ServiceClientHeaders, statusCode: number, body: string, request: ServiceClientRequestParams }} response
  * @throws {ServiceClient.Error}
  * @returns {ServiceClient.Response}
  */
@@ -93,7 +94,8 @@ const decodeResponse = (response) => {
     const clientResponse = new ServiceClient.Response(
         response.statusCode,
         response.headers,
-        response.body
+        response.body,
+        response.request
     );
     clientResponse.timings = response.timings;
     clientResponse.timingPhases = response.timingPhases;
@@ -299,10 +301,12 @@ ServiceClient.CIRCUIT_OPEN = 'Circuit breaker is open and prevented the request'
 ServiceClient.DEFAULT_FILTERS = Object.freeze([ServiceClient.treat5xxAsError]);
 
 ServiceClient.Response = class ServiceClientResponse {
-    constructor(statusCode, headers, body) {
+    // eslint-disable-next-line max-params
+    constructor(statusCode, headers, body, request) {
         this.statusCode = statusCode;
         this.headers = headers;
         this.body = body;
+        this.request = request;
     }
 };
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -57,6 +57,7 @@ module.exports = (options) => {
             });
             bodyStream.on('end', () => {
                 response.body = Buffer.concat(chunks).toString('utf8');
+                response.request = options;
                 hasRequestEnded = true;
                 if (options.timing) {
                     timings.end = getInterval(startTime);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "perron",
-  "version": "0.3.0-beta3",
+  "version": "0.3.0-beta4",
   "description": "A sane client for web services",
   "engines": {
     "node": ">=6.0.0"

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -219,6 +219,23 @@ describe('request', () => {
         responseStub.emit('end');
     });
 
+    it('should attach the request options to the response', (done) => {
+        requestStub.abort = sinon.stub();
+        const responseStub = new ResponseStub();
+        const requestOptions = {
+            test: 'item'
+        };
+        request(requestOptions).then(response => {
+            assert.equal(response.request.test, requestOptions.test);
+            assert(!requestStub.abort.called);
+            done();
+        }).catch(done);
+        clock.tick(100);
+        httpsStub.request.firstCall.args[1](responseStub);
+        clock.tick(100);
+        responseStub.emit('end');
+    });
+
     it('should reject the promise when response arrives but does not finish in time', (done) => {
         requestStub.abort = sinon.stub();
         const responseStub = new ResponseStub();


### PR DESCRIPTION
In filter chains, it might be useful to have the request options as part of the response. This comes in handy, when you want a filter, that measures the request and you can just store the start-time in the options.