### PR TITLE
also add original request to onRetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ There is a shouldRetry function which can be defined in any way by the consumer 
 If the function returns true and the number of retries hasn't been exceeded, the request can be retried.
 
 There is also an onRetry function which can be defined by the user of `perron`. This function is called every time a retry request will be triggered.
-It is provided the currentAttempt, as well as the error that is causing the retry.
+It is provided the currentAttempt, the error that is causing the retry and the original request params.
 
 The first time onRetry gets called, the value of currentAttempt will be 2. This is because the first initial request is counted as the first attempt, and the first retry attempted will then be the second request.
 
@@ -141,8 +141,8 @@ const catWatch = new ServiceClient({
         shouldRetry(err, req) {
             return (err && err.response && err.response.statusCode >= 500);
         },
-        onRetry(currentAttempt, err) {
-            console.log('Retry attempt #' + currentAttempt + 'due to ' + err);
+        onRetry(currentAttempt, err, req) {
+            console.log('Retry attempt #' + currentAttempt + ' for ' + req + ' due to ' + err);
         }
     }
 });

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ const catWatch = new ServiceClient({
             return (err && err.response && err.response.statusCode >= 500);
         },
         onRetry(currentAttempt, err, req) {
-            console.log('Retry attempt #' + currentAttempt + ' for ' + req + ' due to ' + err);
+            console.log('Retry attempt #' + currentAttempt + ' for ' + req.path + ' due to ' + err);
         }
     }
 });

--- a/lib/client.js
+++ b/lib/client.js
@@ -237,7 +237,7 @@ class ServiceClient {
                 return true;
             },
             // eslint-disable-next-line
-            onRetry(currentAttempt, err) {}
+            onRetry(currentAttempt, err, req) {}
         }, this.options.retryOptions);
 
         if (this.options.retryOptions.minTimeout > this.options.retryOptions.maxTimeout) {
@@ -311,7 +311,7 @@ class ServiceClient {
                             reject(error);
                             return;
                         }
-                        onRetry(currentAttempt + 1, error);
+                        onRetry(currentAttempt + 1, error, params);
                     });
             },
             () => {

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -402,9 +402,9 @@ describe('ServiceClient', () => {
         clientOptions.retryOptions = {
             retries: 3,
             onRetry(currentAttempt, err, req) {
-                assert(currentAttempt);
-                assert(err);
-                assert(req);
+                assert(typeof currentAttempt === 'number');
+                assert(typeof err.type === 'string');
+                assert(req.pathname === '/');
                 numberOfRetries += 1;
             }
         };
@@ -432,9 +432,9 @@ describe('ServiceClient', () => {
         clientOptions.retryOptions = {
             retries: 1,
             onRetry(currentAttempt, err, req) {
-                assert(currentAttempt);
-                assert(err);
-                assert(req);
+                assert(typeof currentAttempt === 'number');
+                assert(typeof err.type === 'string');
+                assert(req.pathname === '/');
                 numberOfRetries += 1;
             }
         };
@@ -474,9 +474,9 @@ describe('ServiceClient', () => {
                 return true;
             },
             onRetry(currentAttempt, err, req) {
-                assert(currentAttempt);
-                assert(err);
-                assert(req);
+                assert(typeof currentAttempt === 'number');
+                assert(typeof err.type === 'string');
+                assert(req.pathname === '/');
                 numberOfRetries += 1;
             }
         };

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -401,7 +401,10 @@ describe('ServiceClient', () => {
         let numberOfRetries = 0;
         clientOptions.retryOptions = {
             retries: 3,
-            onRetry() {
+            onRetry(currentAttempt, err, req) {
+                assert(currentAttempt);
+                assert(err);
+                assert(req);
                 numberOfRetries += 1;
             }
         };
@@ -428,7 +431,10 @@ describe('ServiceClient', () => {
         let numberOfRetries = 0;
         clientOptions.retryOptions = {
             retries: 1,
-            onRetry() {
+            onRetry(currentAttempt, err, req) {
+                assert(currentAttempt);
+                assert(err);
+                assert(req);
                 numberOfRetries += 1;
             }
         };
@@ -467,7 +473,10 @@ describe('ServiceClient', () => {
                 }
                 return true;
             },
-            onRetry() {
+            onRetry(currentAttempt, err, req) {
+                assert(currentAttempt);
+                assert(err);
+                assert(req);
                 numberOfRetries += 1;
             }
         };


### PR DESCRIPTION
This is also adding the original request params to the onRetry function.

This allows for the consumer to better log and create metrics based on the reasons for the retry.

(Sorry I should have added this in the previous PR :disappointed:  )