### PR TITLE
Implement the ability to name ServiceClients

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -18,6 +18,7 @@ const retry = require('retry');
 
 /**
  * @typedef {{
+ *  name?: string,
  *  protocol?: string,
  *  service: string,
  *  filters?: Array.<ServiceClient~requestFilter>,
@@ -87,17 +88,18 @@ const retry = require('retry');
 /**
  *
  * @param {{ headers: ServiceClientHeaders, statusCode: number, body: string, request: ServiceClientRequestParams }} response
+ * @param {string} serviceClientName
  * @throws {ServiceClient.Error}
  * @returns {ServiceClient.Response}
  */
-const decodeResponse = (response) => {
+const decodeResponse = (response, serviceClientName) => {
     const contentType = response.headers['content-type'] || (response.body ? 'application/json' : '');
     if (contentType.startsWith('application/json') && typeof response.body !== 'object') {
         try {
             response.body = JSON.parse(response.body);
         } catch (error) {
             throw new ServiceClient.Error(
-                error, ServiceClient.BODY_PARSE_FAILED, response
+                serviceClientName, error, ServiceClient.BODY_PARSE_FAILED, response
             );
         }
     }
@@ -115,15 +117,22 @@ const decodeResponse = (response) => {
 /**
  * Wrapper that makes sure that all error coming out
  * of ServiceClients are of the correct type.
+ * @function ServiceClient~errorWrapper
  * @param {string} type
  * @param {Error} error
  * @param {function=} responseThunk
  * @returns {Promise<Error>}
  */
-const wrapFailedError = (type, error, responseThunk) => {
+
+/**
+ * Builder for a ServiceClient~errorWrapper
+ * @param {string} serviceClientName
+ * @returns {ServiceClient~errorWrapper}
+ */
+const wrapFailedErrorBuilder = (serviceClientName) => (type, error, responseThunk) => {
     error = error instanceof ServiceClient.Error ?
         error :
-        new ServiceClient.Error(error, type);
+        new ServiceClient.Error(serviceClientName, error, type);
     if (!error.response && responseThunk) {
         error.response = responseThunk();
     }
@@ -143,10 +152,12 @@ const unwindResponseFilters = (promise, filter) => {
 /**
  * @param {ServiceClientRequestParams} params
  * @param {Array.<ServiceClientFilter>} filters
+ * @param {string} serviceClientName
  * @returns {Promise.<ServiceClientResponse>}
  */
-const requestWithFilters = (params, filters) => {
+const requestWithFilters = (params, filters, serviceClientName) => {
     const pendingResponseFilters = [];
+    const wrapFailedError = wrapFailedErrorBuilder(serviceClientName);
 
     const requestFilterPromise = filters.reduce((promise, filter) => {
         return promise.then(params => {
@@ -171,7 +182,7 @@ const requestWithFilters = (params, filters) => {
         .then(
             (rawResponse) => {
                 response = rawResponse;
-                return decodeResponse(rawResponse);
+                return decodeResponse(rawResponse, serviceClientName);
             },
             (err) => wrapFailedError(ServiceClient.REQUEST_FAILED, err, responseThunk)
         )
@@ -213,7 +224,8 @@ class ServiceClient {
 
         this.options = Object.assign({
             filters: ServiceClient.DEFAULT_FILTERS,
-            circuitBreaker: {}
+            circuitBreaker: {},
+            name: 'ServiceClient'
         }, options);
 
         if (!this.options.hostname) {
@@ -296,7 +308,7 @@ class ServiceClient {
 
         return new Promise((resolve, reject) => operation.attempt((currentAttempt) => {
             this.breaker.run((success, failure) => {
-                return requestWithFilters(params, this.options.filters)
+                return requestWithFilters(params, this.options.filters, this.options.name)
                     .then(result => {
                         success();
                         resolve(result);
@@ -315,7 +327,7 @@ class ServiceClient {
                     });
             },
             () => {
-                reject(new ServiceClient.Error({}, ServiceClient.CIRCUIT_OPEN));
+                reject(new ServiceClient.Error(this.options.name, {}, ServiceClient.CIRCUIT_OPEN));
             });
         }));
     }
@@ -369,8 +381,9 @@ ServiceClient.Response = class ServiceClientResponse {
 };
 
 ServiceClient.Error = class ServiceClientError extends Error {
-    constructor(originalError, type, response) {
-        super(`${type}. ${originalError.message || ''}`);
+    // eslint-disable-next-line max-params
+    constructor(name, originalError, type, response) {
+        super(`${name}: ${type}. ${originalError.message || ''}`);
         Object.assign(this, originalError);
         this.type = type;
         this.response = response;

--- a/lib/client.js
+++ b/lib/client.js
@@ -225,7 +225,7 @@ class ServiceClient {
         this.options = Object.assign({
             filters: ServiceClient.DEFAULT_FILTERS,
             circuitBreaker: {},
-            name: 'ServiceClient'
+            name: options.hostname
         }, options);
 
         if (!this.options.hostname) {

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -492,12 +492,12 @@ describe('ServiceClient', () => {
         });
     });
 
-    it('should default to `ServiceClient` in errors if no name is specified', (done) => {
+    it('should default to hostname in errors if no name is specified', (done) => {
         const client = new ServiceClient(clientOptions);
         const requestError = new Error('foobar');
         requestStub.returns(Promise.reject(requestError));
         client.request().catch(err => {
-            assert.equal(err.message, 'ServiceClient: HTTP Request failed. foobar');
+            assert.equal(err.message, 'catwatch.opensource.zalan.do: HTTP Request failed. foobar');
             done();
         });
     });

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -480,4 +480,25 @@ describe('ServiceClient', () => {
             done();
         });
     });
+
+    it('should prepend the ServiceClient name to errors', (done) => {
+        clientOptions.name = 'TestClient';
+        const client = new ServiceClient(clientOptions);
+        const requestError = new Error('foobar');
+        requestStub.returns(Promise.reject(requestError));
+        client.request().catch(err => {
+            assert.equal(err.message, 'TestClient: HTTP Request failed. foobar');
+            done();
+        });
+    });
+
+    it('should default to `ServiceClient` in errors if no name is specified', (done) => {
+        const client = new ServiceClient(clientOptions);
+        const requestError = new Error('foobar');
+        requestStub.returns(Promise.reject(requestError));
+        client.request().catch(err => {
+            assert.equal(err.message, 'ServiceClient: HTTP Request failed. foobar');
+            done();
+        });
+    });
 });


### PR DESCRIPTION
This fixes #35 

If there is a name specified, when creating a service client, it is used as a prefix in all errors. If there is no name, it defaults to `ServiceClient`.

I'm not super happy with threading the name through all places, but I've written more horrible code...