### PR TITLE
Ability to name clients

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "perron",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A sane client for web services",
   "engines": {
     "node": ">=6.0.0"

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -290,11 +290,11 @@ describe('ServiceClient', () => {
   describe('built-in filter', () => {
     it('should return original response if all ok', () => {
       return Promise.all([ServiceClient.treat4xxAsError, ServiceClient.treat5xxAsError].map(filter => {
-        const response = {statusCode: 200}
-        return filter.response(response).then((actual) => {
-          assert.deepStrictEqual(actual, response)
+          const response = {statusCode: 200}
+          return filter.response(response).then((actual) => {
+            assert.deepStrictEqual(actual, response)
+          })
         })
-      })
       )
     })
   })
@@ -473,6 +473,25 @@ describe('ServiceClient', () => {
       assert.equal(retrySpy.callCount, 0)
       assert.equal(err instanceof ServiceClient.Error, true)
       assert.equal(err.type, 'Response filter marked request as failed')
+    })
+  })
+
+  it('should prepend the ServiceClient name to errors', () => {
+    clientOptions.name = 'TestClient'
+    const client = new ServiceClient(clientOptions)
+    const requestError = new Error('foobar')
+    requestStub.returns(Promise.reject(requestError))
+    return client.request().catch(err => {
+      assert.equal(err.message, 'TestClient: HTTP Request failed. foobar')
+    })
+  })
+
+  it('should default to hostname in errors if no name is specified', () => {
+    const client = new ServiceClient(clientOptions)
+    const requestError = new Error('foobar')
+    requestStub.returns(Promise.reject(requestError))
+    return client.request().catch(err => {
+      assert.equal(err.message, 'catwatch.opensource.zalan.do: HTTP Request failed. foobar')
     })
   })
 })


### PR DESCRIPTION
This is the TS version of #38

This fixes #35

If there is a name specified, when creating a service client, it is used as a prefix in all errors. If there is no name, it defaults to ServiceClient.

In response to the comments on #38, I tried to not force a change to the `ServiceClientError`. This means there are cases, where the name now defaults to "ServiceClient", since there is nothing else available (backwards compatible). I think this is fine...