### PR TITLE
add the protocol to the published options

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -33,6 +33,10 @@ export interface ServiceClientRequestFilter {
  */
 export class ServiceClientOptions {
   /**
+   * This is the used protocol schema. Possible values: http, https. Defaults to: https.
+   */
+  protocol?: string
+  /**
    * This is the only mandatory option when creating a service client. All other properties have
    * reasonable defaults.
    */


### PR DESCRIPTION
[WIP] Don't merge it yet, please. We found that the port cannot be set, either.

Question formed as a PR: is it fine to add the option to use non-TLS http in the client options? I think it should be to make local testing easier.