### PR TITLE
Fix the types for default request options.

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -65,7 +65,7 @@ export class ServiceClientOptions {
     errorThreshold?: number,
     volumeThreshold?: number
   })
-  defaultRequestOptions?: ServiceClientRequestOptions
+  defaultRequestOptions?: Partial<ServiceClientRequestOptions>
 }
 
 /**
@@ -112,8 +112,8 @@ class ServiceClientStrictOptions {
 
     this.defaultRequestOptions = Object.assign({
       protocol: 'https:',
-      pathname: '/',
-      timeout: 2000
+      port: 443,
+      pathname: '/'
     }, options.defaultRequestOptions)
   }
 }
@@ -219,7 +219,7 @@ export class ServiceClient {
     if (typeof optionsOrUrl === 'string') {
       const parsed = url.parse(optionsOrUrl, true)
       // pathname will be overwritten in actual usage, we just guarantee a sane default
-      const defaultRequestOptions: ServiceClientRequestOptions = { pathname: '/' }
+      const defaultRequestOptions: ServiceClientRequestOptions = { pathname: '/', port: 443, protocol: 'https:' }
       const keys: ('port' | 'protocol' | 'query' | 'pathname')[] = ['port', 'protocol', 'query', 'pathname']
       keys.forEach((option) => {
         if (parsed.hasOwnProperty(option)) {

--- a/lib/request.ts
+++ b/lib/request.ts
@@ -8,8 +8,11 @@ const getInterval = (time: [number, number]): number => {
   return Math.round((diff[0] * 1000) + (diff[1] / 1000000))
 }
 
+
 export interface ServiceClientRequestOptions extends RequestOptions {
+  protocol: string
   pathname: string
+  port: number
   query?: object
   timing?: boolean
   dropRequestAfter?: number
@@ -32,10 +35,6 @@ export type Timings = {lookup: number, socket: number, connect: number, response
 export type TimingPhases = {wait: number, dns: number, tcp: number, firstByte: number, download: number, total: number}
 
 export const request = (options: ServiceClientRequestOptions): Promise<ServiceClientResponse> => {
-  options = Object.assign({
-    protocol: 'https:'
-  }, options)
-
   if ('pathname' in options && !('path' in options)) {
     if ('query' in options) {
       options.path = `${options.pathname}?${querystring.stringify(options.query)}`


### PR DESCRIPTION
One could not specify the port or protocol without using ```as any```