### PR TITLE
introduce connection and read timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.10.0
+
+* Deprecated `dropRequestAfter` in favor of more precise `readTimeout`
+and `timeout` options.
+
 ## 0.9.1
 
 * Having a circuit breaker configured no longer results in Node process

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.10.0
 
-* Deprecated `dropRequestAfter` in favor of more precise `readTimeout`
-and `timeout` options.
+* Added `readTimeout` options to be able to timeout when a socket is
+idle for a certain period of time.
 
 ## 0.9.1
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Each call to `request` method will return a Promise, that would either resolve t
 }
 ```
 
-`request` method accepts an objects with all of the same properties as [https.request](https://nodejs.org/api/https.html#https_https_request_options_callback) method in Node.js, except from a `hostname` field, which is taken from the options passed when creating an instance of `ServiceClient`. Additionally you can add a `dropRequestAfter` field, which defines a timespan in ms after which the request is dropped and the promise is rejected with a `request timeout` error.
+`request` method accepts an objects with all of the same properties as [https.request](https://nodejs.org/api/https.html#https_https_request_options_callback) method in Node.js, except from a `hostname` field, which is taken from the options passed when creating an instance of `ServiceClient`. Additionally you can add a `timeout` and `readTimeout` fields, which define time spans in ms for socket connection and read timeouts.
 
 ## Handling Errors
 
@@ -68,6 +68,9 @@ function logError(err) {
     console.log('Circuit breaker is open');
   } else if (err instanceof RequestConnectionTimeoutError) {
     console.log('Connection timeout');
+    console.log('Request options were', err.requestOptions);
+  } else if (err instanceof RequestReadTimeoutError) {
+    console.log('Socket read timeout');
     console.log('Request options were', err.requestOptions);
   } else if (err instanceof RequestUserTimeoutError) {
     console.log('Request dropped after timeout specified in `dropRequestAfter` option');

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -8,6 +8,7 @@ import * as url from "url";
 import {
   ConnectionTimeoutError,
   NetworkError,
+  ReadTimeoutError,
   request,
   RequestError,
   ServiceClientRequestOptions,
@@ -245,6 +246,15 @@ export class RequestConnectionTimeoutError extends ServiceClientError {
     this.requestOptions = originalError.requestOptions;
   }
 }
+
+export class RequestReadTimeoutError extends ServiceClientError {
+  public requestOptions: ServiceClientRequestOptions;
+  constructor(originalError: RequestError, name: string) {
+    super(originalError, ServiceClient.REQUEST_FAILED, undefined, name);
+    this.requestOptions = originalError.requestOptions;
+  }
+}
+
 export class RequestUserTimeoutError extends ServiceClientError {
   public requestOptions: ServiceClientRequestOptions;
   constructor(originalError: RequestError, name: string) {
@@ -349,6 +359,8 @@ const requestWithFilters = (
               throw new RequestConnectionTimeoutError(error, client.name);
             } else if (error instanceof UserTimeoutError) {
               throw new RequestUserTimeoutError(error, client.name);
+            } else if (error instanceof ReadTimeoutError) {
+              throw new RequestReadTimeoutError(error, client.name);
             } else if (error instanceof NetworkError) {
               throw new RequestNetworkError(error, client.name);
             } else {

--- a/lib/request.ts
+++ b/lib/request.ts
@@ -162,7 +162,7 @@ export const request = (
   }
 
   const connectionTimeout = options.timeout || DEFAULT_CONNECTION_TIMEOUT;
-  const readTimeout = options.timeout || DEFAULT_READ_TIMEOUT;
+  const readTimeout = options.readTimeout || DEFAULT_READ_TIMEOUT;
 
   const httpRequestFn =
     options.protocol === "https:" ? httpsRequest : httpRequest;

--- a/lib/request.ts
+++ b/lib/request.ts
@@ -33,7 +33,6 @@ export interface ServiceClientRequestOptions extends RequestOptions {
   pathname: string;
   query?: object;
   timing?: boolean;
-  /** @deprecated Since 0.10.0 */
   dropRequestAfter?: number;
   body?: any;
   headers?: OutgoingHttpHeaders;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "perron",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "A sane client for web services",
   "engines": {
     "node": ">=8.0.0"

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -218,7 +218,7 @@ describe("request", () => {
     const readTimeout = 100;
     const host = "example.org";
 
-    request({ timeout: readTimeout, host })
+    request({ readTimeout, host })
       .catch(error => {
         assert.strictEqual(error.message, "read timeout");
         sinon.assert.calledWith(requestStub.setTimeout.firstCall, readTimeout);

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -200,7 +200,7 @@ describe("request", () => {
     const host = "example.org";
 
     request({ timeout, host })
-      .catch(error => {
+      .then(fail, error => {
         assert.strictEqual(error.message, "socket timeout");
         sinon.assert.calledWith(socketStub.setTimeout.firstCall, timeout);
         sinon.assert.calledOnce(socketStub.setTimeout);
@@ -219,7 +219,7 @@ describe("request", () => {
     const host = "example.org";
 
     request({ readTimeout, host })
-      .catch(error => {
+      .then(fail, error => {
         assert.strictEqual(error.message, "read timeout");
         sinon.assert.calledWith(requestStub.setTimeout.firstCall, readTimeout);
         sinon.assert.calledOnce(requestStub.setTimeout);


### PR DESCRIPTION
+ Connection timeouts can be controlled already by passing `timeout` in ServiceClientRequestOptions. 
+ Read timeouts can be controlled via new `readTimeout` in ServiceClientRequestOptions. 
