### PR TITLE
Fix error message wrapping for timing errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 language: node_js
 env: CI=true
 sudo: false
-
 node_js:
-    - 6
-    - 7
-    - 8
-
+  - 8
+  - 10
+  - 12
 cache:
   directories:
     - node_modules

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -166,6 +166,7 @@ export class ServiceClientError extends Error {
     name: string = "ServiceClient"
   ) {
     super(`${name}: ${type}. ${originalError.message || ""}`);
+    // Does not copy `message` from the original error
     Object.assign(this, originalError);
     if (originalError instanceof ErrorWithTimings) {
       this.timings = originalError.timings;
@@ -331,7 +332,7 @@ const buildStatusCodeFilter = (
         let error = new Error(`Response status ${response.statusCode}`);
         if (response.timings && response.timingPhases) {
           error = new ErrorWithTimings(
-            { name: "", ...error },
+            error,
             response.timings,
             response.timingPhases
           );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "perron",
-  "version": "0.7.0",
+  "version": "0.7.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "perron",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "perron",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "A sane client for web services",
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   },
   "main": "dist/client.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "perron",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "A sane client for web services",
   "engines": {
     "node": ">=6.0.0"


### PR DESCRIPTION
`Error.prototype.message` is not enumerable, thus we can sometimes loose error message when wrapping filter errors.