### PR TITLE
More detailed error and retry information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,6 @@ Added custom error classes for different error types, including ability to disti
 
 Usage of `type` field on `ServiceClientError` to understand the type of the error is now deprecated in favor of `instanceof` checks for new error classes added in this release.
 
-## 0.6.0
-
-### Breaking Changes
-
-In 0.6.0 we changed the fields of `timings` and `timingPhases` on `ServiceClientResponse` to be nullable, or `undefined`able to be accurate. Previously `timings` had `-1` when a field was missing, and `timingPhases` had wrong numbers in those cases.
-
 ## 0.7.0
 
 ### Breaking Changes
@@ -31,3 +25,9 @@ const {ServiceClient} = require('perron')
 So `ServiceClient` is now a named export.
 
 If you were using babel to transpile your code, no changes should be necessary.
+
+## 0.6.0
+
+### Breaking Changes
+
+In 0.6.0 we changed the fields of `timings` and `timingPhases` on `ServiceClientResponse` to be nullable, or `undefined`able to be accurate. Previously `timings` had `-1` when a field was missing, and `timingPhases` had wrong numbers in those cases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+## 0.9.0
+
+Added custom error classes for different error types, including ability to distinguish connection timeout error, user timeout error, and maximum retries error. For more details see [Handling Errors section in the README](./README.md#handling-errors)
+
+### Deprecation Notices
+
+Usage of `type` field on `ServiceClientError` to understand the type of the error is now deprecated in favor of `instanceof` checks for new error classes added in this release.
+
+## 0.6.0
+
+### Breaking Changes
+
+In 0.6.0 we changed the fields of `timings` and `timingPhases` on `ServiceClientResponse` to be nullable, or `undefined`able to be accurate. Previously `timings` had `-1` when a field was missing, and `timingPhases` had wrong numbers in those cases.
+
+## 0.7.0
+
+### Breaking Changes
+
+In 0.5.0 we changed the exports of the module to be forward-compatible with ES modules. If you are using CommonJS-style require calls, they need to updated from:
+
+```js
+const ServiceClient = require('perron')
+```
+
+to
+
+```js
+const {ServiceClient} = require('perron')
+```
+
+So `ServiceClient` is now a named export.
+
+If you were using babel to transpile your code, no changes should be necessary.

--- a/README.md
+++ b/README.md
@@ -70,34 +70,21 @@ An instance of `ServiceClient.Error` also carries additional information on type
 
 ```js
 catWatch.request({
-    path: '/projects?limit=10'
-}).then(
-    data => console.log(data),
-    dealWithError
-);
+  path: '/projects?limit=10'
+}).then(console.log, dealWithError);
 
 function dealWithError(err) {
-    switch (err.type) {
-        case ServiceClient.REQUEST_FAILED:
-            console.log('HTTP Request failed');
-            break;
-
-        case ServiceClient.BODY_PARSE_FAILED:
-            console.log('Got a JSON response but parsing it failed');
-            break;
-
-        case ServiceClient.REQUEST_FILTER_FAILED:
-            console.log('Request filter failed');
-            break;
-
-        case ServiceClient.RESPONSE_FILTER_FAILED:
-            console.log('Response filter failed');
-            break;
-
-        case ServiceClient.CIRCUIT_OPEN:
-            console.log('Circuit breaker is open');
-            break;
-    }
+  if (err instanceof RequestFailedError) {
+    console.log('HTTP Request failed');
+  } else if (err instanceof BodyParseError) {
+    console.log('Got a JSON response but parsing it failed');
+  } else if (err instanceof RequestFilterError) {
+    console.log('Request filter failed');
+  } else if (err instanceof ResponseFilterError) {
+    console.log('Response filter failed');
+  } else if (err instanceof CircuitOpenError) {
+    console.log('Circuit breaker is open');
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -72,9 +72,13 @@ function logError(err) {
   } else if (err instanceof RequestUserTimeoutError) {
     console.log('Request dropped after timeout specified in `dropRequestAfter` option');
     console.log('Request options were', err.requestOptions);
-  } else if (err instanceof RequestFailedError) {
-    console.log('Unknown error while making the request');
+  } else if (err instanceof RequestNetworkError) {
+    console.log('Network error (socket, dns, etc.)');
     console.log('Request options were', err.requestOptions);
+  } else if (err instanceof InternalError) {
+    // This error should not happen during normal operations
+    // and usually indicates a bug in perron or misconfiguration
+    console.log('Unknown internal error');
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -76,12 +76,15 @@ catWatch.request({
 function dealWithError(err) {
   if (err instanceof RequestFailedError) {
     console.log('HTTP Request failed');
+    console.log('Request options were', err.requestOptions);
   } else if (err instanceof BodyParseError) {
     console.log('Got a JSON response but parsing it failed');
+    console.log('Raw response was', err.response);
   } else if (err instanceof RequestFilterError) {
     console.log('Request filter failed');
   } else if (err instanceof ResponseFilterError) {
     console.log('Response filter failed');
+    console.log('Raw response was', err.response);
   } else if (err instanceof CircuitOpenError) {
     console.log('Circuit breaker is open');
   }

--- a/README.md
+++ b/README.md
@@ -8,27 +8,7 @@ A sane client for web services with a built-in circuit-breaker, support for filt
 npm install perron --save
 ```
 
-## Breaking Change in Version 0.6
-
-In 0.6.0 we changed the fields of `timings` and `timingPhases` on `ServiceClientResponse` to be nullable, or `undefined`able to be accurate. Previously `timings` had `-1` when a field was missing, and `timingPhases` had wrong numbers in those cases.
-
-## Breaking Change in Version 0.5
-
-In 0.5.0 we changed the exports of the module to be forward-compatible with ES modules. If you are using CommonJS-style require calls, they need to updated from:
-
-```js
-const ServiceClient = require('perron')
-```
-
-to
-
-```js
-const {ServiceClient} = require('perron')
-```
-
-So `ServiceClient` is now a named export.
-
-If you were using babel to transpile your code, no changes should be necessary.
+**[Changelog](https://github.com/zalando-incubator/perron/blob/master/CHANGELOG.md)**
 
 ## Quick Example
 

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -162,13 +162,19 @@ export abstract class ServiceClientError extends Error {
   public timings?: Timings;
   public timingPhases?: TimingPhases;
   public retryErrors: ServiceClientError[];
+  /**
+   * Use `instanceof` checks instead.
+   * @deprecated since 0.9.0
+   */
+  public type: string;
   protected constructor(
     originalError: Error,
-    public type: string,
+    type: string,
     public response?: ServiceClientResponse,
     name: string = "ServiceClient"
   ) {
     super(`${name}: ${type}. ${originalError.message || ""}`);
+    this.type = type;
     this.retryErrors = [];
     // Does not copy `message` from the original error
     Object.assign(this, originalError);
@@ -381,33 +387,33 @@ export class ServiceClient {
 
   /**
    * Use `instanceof BodyParseError` check instead
-   * @deprecated
+   * @deprecated since 0.9.0
    */
   public static BODY_PARSE_FAILED = "Parsing of the response body failed";
 
   /**
    * Use `instanceof RequestFailedError` check instead
-   * @deprecated
+   * @deprecated since 0.9.0
    */
   public static REQUEST_FAILED = "HTTP Request failed";
 
   /**
    * Use `instanceof RequestFilterError` check instead
-   * @deprecated
+   * @deprecated since 0.9.0
    */
   public static REQUEST_FILTER_FAILED =
     "Request filter marked request as failed";
 
   /**
    * Use `instanceof ResponseFilterError` check instead
-   * @deprecated
+   * @deprecated since 0.9.0
    */
   public static RESPONSE_FILTER_FAILED =
     "Response filter marked request as failed";
 
   /**
    * Use `instanceof CircuitOpenError` check instead
-   * @deprecated
+   * @deprecated since 0.9.0
    */
   public static CIRCUIT_OPEN =
     "Circuit breaker is open and prevented the request";

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -529,6 +529,7 @@ export class ServiceClient {
     };
 
     const operation = retry.operation(opts);
+    const retryErrors: ServiceClientError[] = [];
 
     const breaker = this.getCircuitBreaker(params);
 
@@ -544,9 +545,11 @@ export class ServiceClient {
             )
               .then((result: ServiceClientResponse) => {
                 success();
+                result.retryErrors = retryErrors;
                 resolve(result);
               })
-              .catch((error: Error) => {
+              .catch((error: ServiceClientError) => {
+                retryErrors.push(error);
                 failure();
                 if (!shouldRetry(error, params)) {
                   reject(error);

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -3,6 +3,7 @@ import * as retry from "retry";
 import * as url from "url";
 import {
   request,
+  RequestError,
   ServiceClientRequestOptions,
   ServiceClientResponse,
   TimingPhases,
@@ -212,8 +213,10 @@ export class ResponseFilterError extends ServiceClientError {
 }
 
 export class RequestFailedError extends ServiceClientError {
-  constructor(originalError: Error, name: string) {
+  public requestOptions: ServiceClientRequestOptions;
+  constructor(originalError: RequestError, name: string) {
     super(originalError, ServiceClient.REQUEST_FAILED, undefined, name);
+    this.requestOptions = originalError.requestOptions;
   }
 }
 
@@ -290,7 +293,7 @@ const requestWithFilters = (
     .then(paramsOrResponse =>
       paramsOrResponse instanceof ServiceClientResponse
         ? paramsOrResponse
-        : request(paramsOrResponse).catch(error => {
+        : request(paramsOrResponse).catch((error: RequestError) => {
             throw new RequestFailedError(error, client.name);
           })
     )

--- a/lib/request.ts
+++ b/lib/request.ts
@@ -87,6 +87,17 @@ export class RequestError extends Error {
   }
 }
 
+export class NetworkError extends RequestError {
+  constructor(
+    originalError: Error,
+    requestOptions: ServiceClientRequestOptions,
+    timings?: Timings
+  ) {
+    super(originalError.message, requestOptions, timings);
+    this.stack = originalError.stack;
+  }
+}
+
 export class ConnectionTimeoutError extends RequestError {
   constructor(requestOptions: ServiceClientRequestOptions, timings?: Timings) {
     super("socket timeout", requestOptions, timings);
@@ -218,7 +229,7 @@ export const request = (
       });
     }
     requestObject.on("error", error =>
-      reject(new RequestError(error.message, options, timings))
+      reject(new NetworkError(error, options, timings))
     );
     requestObject.on("timeout", () => {
       requestObject.abort();

--- a/lib/request.ts
+++ b/lib/request.ts
@@ -40,7 +40,6 @@ export class ServiceClientResponse {
     public statusCode: number,
     public headers: IncomingHttpHeaders,
     public body: any,
-    // tslint:disable-next-line
     public request: ServiceClientRequestOptions
   ) {}
 }

--- a/lib/request.ts
+++ b/lib/request.ts
@@ -6,6 +6,7 @@ import {
 import { request as httpsRequest, RequestOptions } from "https";
 import * as querystring from "querystring";
 import * as zlib from "zlib";
+import { ServiceClientError } from "./client";
 
 const getInterval = (time: [number, number]): number => {
   const diff = process.hrtime(time);
@@ -36,12 +37,15 @@ export interface ServiceClientRequestOptions extends RequestOptions {
 export class ServiceClientResponse {
   public timings?: Timings;
   public timingPhases?: TimingPhases;
+  public retryErrors: ServiceClientError[];
   constructor(
     public statusCode: number,
     public headers: IncomingHttpHeaders,
     public body: any,
     public request: ServiceClientRequestOptions
-  ) {}
+  ) {
+    this.retryErrors = [];
+  }
 }
 
 export interface Timings {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "perron",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   "scripts": {
     "prepublishOnly": "npm run test && npm run docs",
     "lint": "eslint . --ext .ts,.tsx,.js",
-    "test": "npm run lint && tsc && mocha test",
-    "test-cov": "npm run lint && tsc && nyc --check-coverage --lines 90 --functions 85 --branches 85 mocha test",
-    "tdd": "mocha test --watch"
+    "test": "npm run lint && tsc && mocha --exit test",
+    "test-cov": "npm run lint && tsc && nyc --check-coverage --lines 90 --functions 85 --branches 85 mocha --exit test",
+    "tdd": "mocha test --exit --watch"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "perron",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "A sane client for web services",
   "engines": {
     "node": ">=8.0.0"

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -545,6 +545,29 @@ describe("ServiceClient", () => {
     });
   });
 
+  it("should correctly return response if one of the retries succeeds", () => {
+    const retrySpy = sinon.spy();
+    clientOptions.retryOptions = {
+      retries: 3,
+      onRetry: retrySpy
+    };
+    const client = new ServiceClient(clientOptions);
+    requestStub.onFirstCall().resolves({
+      statusCode: 501,
+      headers: {},
+      body: "{}"
+    });
+    requestStub.onSecondCall().resolves({
+      statusCode: 200,
+      headers: {},
+      body: `{"foo":"bar"}`
+    });
+    return client.request().then(response => {
+      assert.equal(retrySpy.callCount, 1);
+      assert.deepEqual(response.body, { foo: "bar" });
+    });
+  });
+
   it("should perform the desired number of retries based on the configuration", () => {
     const retrySpy = sinon.spy();
     clientOptions.retryOptions = {

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -1,12 +1,15 @@
 "use strict";
 
+const util = require("util");
 const assert = require("assert");
 const proxyquire = require("proxyquire").noCallThru();
 const sinon = require("sinon");
 const realRequest = require("../dist/request");
 
 const fail = result =>
-  assert.fail(`expected promise to be rejected, got resolved with ${result}`);
+  assert.fail(
+    `expected promise to be rejected, got resolved with ${util.inspect(result)}`
+  );
 
 describe("ServiceClient", () => {
   /**

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -25,7 +25,9 @@ describe("ServiceClient", () => {
     ResponseFilterError,
     RequestFailedError,
     RequestConnectionTimeoutError,
-    RequestUserTimeoutError
+    RequestUserTimeoutError,
+    MaximumRetriesReachedError,
+    ShouldRetryRejectedError
   } = proxyquire("../dist/client", {
     "./request": fakeRequest
   });
@@ -595,7 +597,11 @@ describe("ServiceClient", () => {
       );
       assert.equal(err instanceof ServiceClient.Error, true);
       assert.equal(err.type, "Response filter marked request as failed");
-      assert(err instanceof ResponseFilterError);
+      assert(err instanceof MaximumRetriesReachedError);
+      assert.equal(err.retryErrors.length, 4);
+      for (const originalError of err.retryErrors) {
+        assert(originalError instanceof ResponseFilterError);
+      }
     });
   });
 
@@ -681,7 +687,7 @@ describe("ServiceClient", () => {
       assert.equal(retrySpy.callCount, 0);
       assert.equal(err instanceof ServiceClient.Error, true);
       assert.equal(err.type, "Response filter marked request as failed");
-      assert(err instanceof ResponseFilterError);
+      assert(err instanceof ShouldRetryRejectedError);
     });
   });
 

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -565,6 +565,8 @@ describe("ServiceClient", () => {
     return client.request().then(response => {
       assert.equal(retrySpy.callCount, 1);
       assert.deepEqual(response.body, { foo: "bar" });
+      assert.equal(response.retryErrors.length, 1);
+      assert(response.retryErrors[0] instanceof ResponseFilterError);
     });
   });
 

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -23,11 +23,17 @@ describe("ServiceClient", () => {
     CircuitOpenError,
     RequestFilterError,
     ResponseFilterError,
-    RequestFailedError
+    RequestFailedError,
+    RequestConnectionTimeoutError,
+    RequestUserTimeoutError
   } = proxyquire("../dist/client", {
     "./request": fakeRequest
   });
-  const { RequestError } = fakeRequest;
+  const {
+    RequestError,
+    ConnectionTimeoutError,
+    UserTimeoutError
+  } = fakeRequest;
   const timings = {
     socket: 1,
     lookup: 2,
@@ -180,6 +186,24 @@ describe("ServiceClient", () => {
       assert(err instanceof ServiceClient.Error);
       assert.equal(err.type, ServiceClient.REQUEST_FAILED);
       assert(err instanceof RequestFailedError);
+    });
+  });
+
+  it("should give a custom error when request timeouts", () => {
+    const client = new ServiceClient(clientOptions);
+    requestStub.rejects(new ConnectionTimeoutError("foobar"));
+    return client.request().catch(err => {
+      assert(err instanceof ServiceClient.Error);
+      assert(err instanceof RequestConnectionTimeoutError);
+    });
+  });
+
+  it("should give a custom error when request is dropped", () => {
+    const client = new ServiceClient(clientOptions);
+    requestStub.rejects(new UserTimeoutError("foobar"));
+    return client.request().catch(err => {
+      assert(err instanceof ServiceClient.Error);
+      assert(err instanceof RequestUserTimeoutError);
     });
   });
 

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -111,11 +111,10 @@ describe("request", () => {
     assert(typeof request().then, "function");
   });
 
-  it("should reject a promise if request errors out", done => {
-    request().catch(() => {
-      done();
-    });
-    requestStub.emit("error");
+  it("should reject a promise if request errors out", () => {
+    const requestPromise = request();
+    requestStub.emit("error", new Error("foo"));
+    return requestPromise.catch(err => assert.equal(err.message, "foo"));
   });
 
   it("should use the body of the request if one is provided", () => {


### PR DESCRIPTION
This PR should completely backwards compatible with previous way of handling different error types (which is now deprecated) while providing extra information requested in #24 and #72.

It also provides better type information for TypeScript users because `instanceof` checks.

I recommend reviewing this PR commit-by-commit to better follow the changes.