### PR TITLE
Pull in circuit breaker code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.9.1
+
+* Having a circuit breaker configured no longer results in Node process
+not exiting properly.
+* Improved circuit breaker performance and memory usage.
+
 ## 0.9.0
 
 Added custom error classes for different error types, including ability to distinguish connection timeout error, user timeout error, and maximum retries error. For more details see [Handling Errors section in the README](./README.md#handling-errors)

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,9 @@
+Copyright for portions of circuit breaker code are held by Yammer Inc.
+All other copyright for Perron are held by Zalando.
+
 The MIT License
 
+Copyright (c) 2013 Yammer Inc.
 Copyright (c) 2016 Zalando SE
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/lib/circuit-breaker.ts
+++ b/lib/circuit-breaker.ts
@@ -140,7 +140,7 @@ export class CircuitBreaker implements CircuitBreakerPublicApi {
       self.buckets.push(createBucket());
     };
 
-    setInterval(tick, bucketDuration);
+    setInterval(tick, bucketDuration).unref();
   }
 
   private lastBucket() {

--- a/lib/circuit-breaker.ts
+++ b/lib/circuit-breaker.ts
@@ -1,0 +1,229 @@
+// Based on https://github.com/yammer/circuit-breaker-js
+
+export interface CircuitBreakerOptions {
+  /** milliseconds */
+  windowDuration?: number;
+  numBuckets?: number;
+  /** milliseconds */
+  timeoutDuration?: number;
+  /** percentage */
+  errorThreshold?: number;
+  /** absolute number */
+  volumeThreshold?: number;
+
+  onCircuitOpen?: (m: Metrics) => void;
+  onCircuitClose?: (m: Metrics) => void;
+}
+
+const enum State {
+  OPEN,
+  HALF_OPEN,
+  CLOSED
+}
+
+export interface Metrics {
+  totalCount: number;
+  errorCount: number;
+  errorPercentage: number;
+}
+
+interface Bucket {
+  failures: number;
+  successes: number;
+  timeouts: number;
+  shortCircuits: number;
+}
+
+function createBucket(): Bucket {
+  return {
+    failures: 0,
+    successes: 0,
+    timeouts: 0,
+    shortCircuits: 0
+  };
+}
+
+export type Command = (success: () => void, failure: () => void) => void;
+
+function noop() {}
+
+export interface CircuitBreakerPublicApi {
+  run(command: Command, fallback?: () => void): void;
+  forceClose(): void;
+  forceOpen(): void;
+  unforce(): void;
+  isOpen(): boolean;
+}
+
+export class CircuitBreaker implements CircuitBreakerPublicApi {
+  public windowDuration: number;
+  public numBuckets: number;
+  public timeoutDuration: number;
+  public errorThreshold: number;
+  public volumeThreshold: number;
+
+  public onCircuitOpen: (m: Metrics) => void;
+  public onCircuitClose: (m: Metrics) => void;
+
+  private readonly buckets: Bucket[];
+  private state: State;
+  private forced?: State;
+
+  constructor(options?: CircuitBreakerOptions) {
+    options = options || {};
+
+    this.windowDuration = options.windowDuration || 10000;
+    this.numBuckets = options.numBuckets || 10;
+    this.timeoutDuration = options.timeoutDuration || 3000;
+    this.errorThreshold = options.errorThreshold || 50;
+    this.volumeThreshold = options.volumeThreshold || 5;
+
+    this.onCircuitOpen = options.onCircuitOpen || noop;
+    this.onCircuitClose = options.onCircuitClose || noop;
+
+    this.buckets = [createBucket()];
+    this.state = State.CLOSED;
+    this.forced = undefined;
+
+    this.startTicker();
+  }
+
+  public run(command: Command, fallback?: () => void) {
+    if (this.isOpen()) {
+      this.executeFallback(fallback || function() {});
+    } else {
+      this.executeCommand(command);
+    }
+  }
+
+  public forceClose() {
+    this.forced = this.state;
+    this.state = State.CLOSED;
+  }
+
+  public forceOpen() {
+    this.forced = this.state;
+    this.state = State.OPEN;
+  }
+
+  public unforce() {
+    if (this.forced !== undefined) {
+      this.state = this.forced;
+      this.forced = undefined;
+    }
+  }
+
+  public isOpen() {
+    return this.state === State.OPEN;
+  }
+
+  private startTicker() {
+    const self = this;
+    let bucketIndex = 0;
+    const bucketDuration = this.windowDuration / this.numBuckets;
+
+    const tick = function() {
+      if (self.buckets.length > self.numBuckets) {
+        self.buckets.shift();
+      }
+
+      bucketIndex++;
+
+      if (bucketIndex > self.numBuckets) {
+        bucketIndex = 0;
+
+        if (self.isOpen()) {
+          self.state = State.HALF_OPEN;
+        }
+      }
+
+      self.buckets.push(createBucket());
+    };
+
+    setInterval(tick, bucketDuration);
+  }
+
+  private lastBucket() {
+    return this.buckets[this.buckets.length - 1];
+  }
+
+  private executeCommand(command: Command) {
+    const self = this;
+    let timeout: NodeJS.Timer | undefined;
+
+    const increment = function(prop: keyof Bucket) {
+      return function() {
+        if (!timeout) {
+          return;
+        }
+
+        const bucket = self.lastBucket();
+        bucket[prop]++;
+
+        if (self.forced == null) {
+          self.updateState();
+        }
+
+        clearTimeout(timeout);
+        timeout = undefined;
+      };
+    };
+
+    timeout = setTimeout(increment("timeouts"), this.timeoutDuration);
+
+    command(increment("successes"), increment("failures"));
+  }
+
+  private executeFallback(fallback: () => void) {
+    fallback();
+
+    const bucket = this.lastBucket();
+    bucket.shortCircuits++;
+  }
+
+  private calculateMetrics() {
+    let totalCount = 0;
+    let errorCount = 0;
+
+    for (const bucket of this.buckets) {
+      const errors = bucket.failures + bucket.timeouts;
+
+      errorCount += errors;
+      totalCount += errors + bucket.successes;
+    }
+
+    const errorPercentage =
+      (errorCount / (totalCount > 0 ? totalCount : 1)) * 100;
+
+    return {
+      totalCount,
+      errorCount,
+      errorPercentage
+    };
+  }
+
+  private updateState() {
+    const metrics = this.calculateMetrics();
+
+    if (this.state == State.HALF_OPEN) {
+      const lastCommandFailed =
+        !this.lastBucket().successes && metrics.errorCount > 0;
+
+      if (lastCommandFailed) {
+        this.state = State.OPEN;
+      } else {
+        this.state = State.CLOSED;
+        this.onCircuitClose(metrics);
+      }
+    } else {
+      const overErrorThreshold = metrics.errorPercentage > this.errorThreshold;
+      const overVolumeThreshold = metrics.totalCount > this.volumeThreshold;
+      const overThreshold = overVolumeThreshold && overErrorThreshold;
+
+      if (overThreshold) {
+        this.state = State.OPEN;
+        this.onCircuitOpen(metrics);
+      }
+    }
+  }
+}

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -17,7 +17,13 @@ import {
   UserTimeoutError
 } from "./request";
 
-export { ServiceClientResponse, ServiceClientRequestOptions };
+export {
+  CircuitBreaker,
+  CircuitBreakerOptions,
+  CircuitBreakerPublicApi,
+  ServiceClientResponse,
+  ServiceClientRequestOptions
+};
 
 /**
  * This interface defines factory function for getting a circuit breaker

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -1,4 +1,8 @@
-import * as CircuitBreaker from "circuit-breaker-js";
+import {
+  CircuitBreaker,
+  CircuitBreakerOptions,
+  CircuitBreakerPublicApi
+} from "./circuit-breaker";
 import * as retry from "retry";
 import * as url from "url";
 import {
@@ -82,10 +86,7 @@ export class ServiceClientOptions {
       req?: ServiceClientRequestOptions
     ) => void;
   };
-  public circuitBreaker?:
-    | false
-    | CircuitBreaker.Options
-    | CircuitBreakerFactory;
+  public circuitBreaker?: false | CircuitBreakerOptions | CircuitBreakerFactory;
   public defaultRequestOptions?: Partial<ServiceClientRequestOptions>;
 }
 
@@ -364,7 +365,7 @@ const requestWithFilters = (
 const noop = () => {
   /* do nothing */
 };
-const noopBreaker: CircuitBreaker = {
+const noopBreaker: CircuitBreakerPublicApi = {
   run(command) {
     command(noop, noop);
   },
@@ -530,7 +531,7 @@ export class ServiceClient {
    */
   public getCircuitBreaker(
     params: ServiceClientRequestOptions
-  ): CircuitBreaker {
+  ): CircuitBreakerPublicApi {
     if (this.breaker) {
       return this.breaker;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -147,11 +147,6 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
-    "@types/circuit-breaker-js": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@types/circuit-breaker-js/-/circuit-breaker-js-0.0.1.tgz",
-      "integrity": "sha512-fm4q9Vvv1AwwnkXcE0l4IFvhiN4tI2Xo0XpRj14K46s+w0bemp5YuDlIMW6eE7GqnY8dGheDHzrd/7Cj0WhW4g=="
-    },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
@@ -389,11 +384,6 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
-    },
-    "circuit-breaker-js": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/circuit-breaker-js/-/circuit-breaker-js-0.0.1.tgz",
-      "integrity": "sha1-X2TI9kUjzJ0YzRRZ8FTvVXqxdnw="
     },
     "cli-cursor": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "perron",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "A sane client for web services",
   "engines": {
     "node": ">=8.0.0"
@@ -9,9 +9,9 @@
   "scripts": {
     "prepublishOnly": "npm run test",
     "lint": "eslint . --ext .ts,.tsx,.js",
-    "test": "npm run lint && tsc && mocha --exit test",
-    "test-cov": "npm run lint && tsc && nyc --check-coverage --lines 90 --functions 85 --branches 85 mocha --exit test",
-    "tdd": "mocha test --exit --watch"
+    "test": "npm run lint && tsc && mocha test",
+    "test-cov": "npm run lint && tsc && nyc --check-coverage --lines 90 --functions 85 --branches 85 mocha test",
+    "tdd": "mocha test --watch"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -40,8 +40,6 @@
     "typescript": "^3.5.1"
   },
   "dependencies": {
-    "@types/circuit-breaker-js": "^0.0.1",
-    "circuit-breaker-js": "^0.0.1",
     "retry": "^0.12.0"
   }
 }

--- a/test/circuit-breaker.test.js
+++ b/test/circuit-breaker.test.js
@@ -1,0 +1,397 @@
+const { CircuitBreaker } = require("../dist/circuit-breaker");
+const assert = require("assert").strict;
+const sinon = require("sinon");
+
+describe("CircuitBreaker", function() {
+  let breaker;
+  let clock;
+
+  const success = function() {
+    const command = function(success) {
+      success();
+    };
+
+    breaker.run(command);
+  };
+
+  const fail = function() {
+    const command = function(success, failed) {
+      failed();
+    };
+
+    breaker.run(command);
+  };
+
+  const timeout = function() {
+    const command = function() {};
+    breaker.run(command);
+
+    clock.tick(1000);
+    clock.tick(1000);
+    clock.tick(1000);
+  };
+
+  beforeEach(function() {
+    clock = sinon.useFakeTimers();
+    breaker = new CircuitBreaker();
+  });
+
+  describe("with a working service", function() {
+    it("should run the command", function() {
+      const command = sinon.spy();
+      breaker.run(command);
+
+      sinon.assert.called(command);
+    });
+
+    it("should be able to notify the breaker if the command was successful", function() {
+      success();
+
+      const bucket = breaker.lastBucket();
+      assert.equal(bucket.successes, 1);
+    });
+
+    it("should be able to notify the breaker if the command failed", function() {
+      fail();
+
+      const bucket = breaker.lastBucket();
+      assert.equal(bucket.failures, 1);
+    });
+
+    it("should record a timeout if not a success or failure", function() {
+      timeout();
+
+      const bucket = breaker.lastBucket();
+      assert.equal(bucket.timeouts, 1);
+    });
+
+    it("should not call timeout if there is a success", function() {
+      success();
+
+      clock.tick(1000);
+      clock.tick(1000);
+      clock.tick(1000);
+
+      const bucket = breaker.lastBucket();
+      assert.equal(bucket.timeouts, 0);
+    });
+
+    it("should not call timeout if there is a failure", function() {
+      fail();
+
+      clock.tick(1000);
+      clock.tick(1000);
+      clock.tick(1000);
+
+      const bucket = breaker.lastBucket();
+      assert.equal(bucket.timeouts, 0);
+    });
+
+    it("should not record a success when there is a timeout", function() {
+      const command = function(success) {
+        clock.tick(1000);
+        clock.tick(1000);
+        clock.tick(1000);
+
+        success();
+      };
+
+      breaker.run(command);
+
+      const bucket = breaker.lastBucket();
+      assert.equal(bucket.successes, 0);
+    });
+
+    it("should not record a failure when there is a timeout", function() {
+      const command = function(success, fail) {
+        clock.tick(1000);
+        clock.tick(1000);
+        clock.tick(1000);
+
+        fail();
+      };
+
+      breaker.run(command);
+
+      const bucket = breaker.lastBucket();
+      assert.equal(bucket.failures, 0);
+    });
+  });
+
+  describe("with a broken service", function() {
+    beforeEach(function() {
+      sinon.stub(breaker, "isOpen").returns(true);
+    });
+
+    it("should not run the command", function() {
+      const command = sinon.spy();
+      breaker.run(command);
+
+      sinon.assert.notCalled(command);
+    });
+
+    it("should run the fallback if one is provided", function() {
+      const command = sinon.spy();
+      const fallback = sinon.spy();
+
+      breaker.run(command, fallback);
+
+      sinon.assert.called(fallback);
+    });
+
+    it("should record a short circuit", function() {
+      const command = sinon.spy();
+      breaker.run(command);
+
+      sinon.assert.notCalled(command);
+
+      const bucket = breaker.lastBucket();
+      assert.equal(bucket.shortCircuits, 1);
+    });
+  });
+
+  describe("isOpen", function() {
+    it("should be false if errors are below the threshold", function() {
+      breaker.errorThreshold = 75;
+
+      fail();
+      fail();
+      fail();
+      success();
+
+      assert.equal(breaker.isOpen(), false);
+    });
+
+    it("should be true if errors are above the threshold", function() {
+      breaker.errorThreshold = 75;
+
+      fail();
+      fail();
+      fail();
+      fail();
+      fail();
+      success();
+
+      assert.equal(breaker.isOpen(), true);
+    });
+
+    it("should be true if timeouts are above the threshold", function() {
+      breaker.errorThreshold = 25;
+      breaker.volumeThreshold = 1;
+
+      timeout();
+      timeout();
+      success();
+
+      assert.equal(breaker.isOpen(), true);
+    });
+
+    it("should maintain failed state after window has passed", function() {
+      breaker.errorThreshold = 25;
+      breaker.volumeThreshold = 1;
+
+      fail();
+      fail();
+      fail();
+      fail();
+
+      clock.tick(11001);
+
+      fail();
+
+      assert.equal(breaker.isOpen(), true);
+    });
+
+    it("should retry after window has elapsed", function() {
+      fail();
+      fail();
+      fail();
+      fail();
+
+      clock.tick(11001);
+
+      const command = sinon.spy();
+      breaker.run(command);
+
+      sinon.assert.called(command);
+    });
+
+    it("should include errors within the current time window", function() {
+      breaker.errorThreshold = 75;
+
+      fail();
+      fail();
+      fail();
+      fail();
+      fail();
+      success();
+
+      clock.tick(1001);
+
+      assert.equal(breaker.isOpen(), true);
+    });
+
+    it("should not be broken without having more than minimum number of errors", function() {
+      breaker.errorThreshold = 25;
+      breaker.volumeThreshold = 1;
+
+      fail();
+
+      assert.equal(breaker.isOpen(), false);
+    });
+  });
+
+  describe("logging", function() {
+    let openSpy;
+    let closeSpy;
+
+    beforeEach(function() {
+      openSpy = sinon.spy();
+      closeSpy = sinon.spy();
+
+      breaker.volumeThreshold = 1;
+      breaker.onCircuitOpen = openSpy;
+      breaker.onCircuitClose = closeSpy;
+    });
+
+    it("should call the onCircuitOpen method when a failure is recorded", function() {
+      fail();
+      fail();
+
+      sinon.assert.called(openSpy);
+    });
+
+    it("should call the onCircuitClosed method when the break is successfully reset", function() {
+      fail();
+      fail();
+      fail();
+      fail();
+
+      clock.tick(11001);
+
+      success();
+
+      sinon.assert.called(closeSpy);
+    });
+  });
+
+  describe("forceClose", function() {
+    it("should bypass threshold checks", function() {
+      fail();
+      fail();
+      fail();
+      fail();
+      fail();
+      fail();
+
+      breaker.forceClose();
+
+      const command = sinon.spy();
+      breaker.run(command);
+
+      sinon.assert.called(command);
+      assert.equal(breaker.isOpen(), false);
+    });
+
+    it("should not collect stats", function() {
+      fail();
+      fail();
+      fail();
+      fail();
+      fail();
+      fail();
+
+      breaker.forceClose();
+      success();
+      success();
+      success();
+      success();
+      success();
+
+      const command = sinon.spy();
+      breaker.run(command);
+
+      sinon.assert.called(command);
+      assert.equal(breaker.isOpen(), false);
+    });
+  });
+
+  describe("forceOpen", function() {
+    it("should bypass threshold checks", function() {
+      success();
+      success();
+      success();
+      success();
+      success();
+      success();
+
+      breaker.forceOpen();
+
+      const command = sinon.spy();
+      breaker.run(command);
+
+      sinon.assert.notCalled(command);
+      assert.equal(breaker.isOpen(), true);
+    });
+
+    it("should not collect stats", function() {
+      success();
+      success();
+      success();
+      success();
+      success();
+      success();
+
+      breaker.forceOpen();
+      fail();
+      fail();
+      fail();
+      fail();
+      fail();
+
+      const command = sinon.spy();
+      breaker.run(command);
+
+      sinon.assert.notCalled(command);
+      assert.equal(breaker.isOpen(), true);
+    });
+  });
+
+  describe("unforce", function() {
+    it("should recover from a force-closed circuit", function() {
+      fail();
+      fail();
+      fail();
+      fail();
+      fail();
+      fail();
+
+      breaker.forceClose();
+      breaker.unforce();
+
+      const command = sinon.spy();
+      breaker.run(command);
+
+      sinon.assert.notCalled(command);
+      assert.equal(breaker.isOpen(), true);
+    });
+
+    it("should recover from a force-open circuit", function() {
+      success();
+      success();
+      success();
+      success();
+      success();
+      success();
+
+      breaker.forceOpen();
+      breaker.unforce();
+
+      const command = sinon.spy();
+      breaker.run(command);
+
+      sinon.assert.called(command);
+      assert.equal(breaker.isOpen(), false);
+    });
+  });
+});

--- a/test/circuit-breaker.test.js
+++ b/test/circuit-breaker.test.js
@@ -36,6 +36,10 @@ describe("CircuitBreaker", function() {
     breaker = new CircuitBreaker();
   });
 
+  afterEach(function() {
+    clock.restore();
+  });
+
   describe("with a working service", function() {
     it("should run the command", function() {
       const command = sinon.spy();

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -62,9 +62,6 @@ describe("request", () => {
     clock.restore();
   });
 
-  afterEach(() => {
-    clock.restore();
-  });
   it("should call https if protocol is not specified", () => {
     request();
     assert.equal(httpsStub.request.callCount, 1);


### PR DESCRIPTION
The reasoning behind this PR is the circuit breaker code we are using hasn't been updated in years and has some minor annoyances (like not `unref`ing timers) and some bigger algorithmic issues. Pulling it in allows us to fix those and integrate it deeper into the main code.

### Changes

* Circuit breaker code is now directly included instead of being an NPM dependency
* Having a circuit breaker configured no longer results in Node process not exiting properly.
* Improved circuit breaker performance and memory usage by using a circular buffer instead of `unshift` / `pop` operations.