### PR TITLE
Export CircuitBreakerMetrics

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -1,6 +1,7 @@
 import {
   CircuitBreaker,
   CircuitBreakerOptions,
+  Metrics as CircuitBreakerMetrics,
   CircuitBreakerPublicApi
 } from "./circuit-breaker";
 import * as retry from "retry";
@@ -21,6 +22,7 @@ import {
 export {
   CircuitBreaker,
   CircuitBreakerOptions,
+  CircuitBreakerMetrics,
   CircuitBreakerPublicApi,
   ServiceClientResponse,
   ServiceClientRequestOptions


### PR DESCRIPTION
Allow library users to refer to `Metrics` in circuit-breaker.ts when
setting `onCircuitOpen` or `onCircuitClose` handlers.