### PR TITLE
Bump package-lock.json version to 0.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "perron",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Increase the version in package-lock.json because 0.10.0 was already
released.