### PR TITLE
Release 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
-## 0.10.0
+## 0.11.0
 
+* Added `span` option where the tcp events will be logged. The interface matches the opentracing span interface.
+* Improved retries performance and memory usage.
+
+## 0.10.0
+                                  
 * Added `readTimeout` options to be able to timeout when a socket is
 idle for a certain period of time.
 

--- a/README.md
+++ b/README.md
@@ -284,6 +284,10 @@ By default Perron will try to parse JSON body if the `content-type` header is no
 it is specified as `application/json`. If you wish to disable this behavior you can use
 `autoParseJson: false` option when constructing `ServiceClient` object.
 
+### Opentracing
+
+Perron accepts a Span like object where it will log the network and request related events.
+
 ## License
 
 The MIT License

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "perron",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "perron",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "A sane client for web services",
   "engines": {
     "node": ">=8.0.0"


### PR DESCRIPTION
* Added `span` option where the tcp events will be logged. The interface matches the opentracing span interface.
* Improved retries performance and memory usage.

Blocked by #86 