### PR TITLE
Flag request as ended on request error

### DIFF
--- a/lib/request.ts
+++ b/lib/request.ts
@@ -225,6 +225,7 @@ export const request = (
     });
 
     requestObject.once("error", err => {
+      hasRequestEnded = true;
       logEvent(EventSource.HTTP_REQUEST, EventName.ERROR, err.message);
       reject(new NetworkError(err, options));
     });


### PR DESCRIPTION
Requests are not ended when an error happens. This results in trying to abort a request that already ended:
````
Error [ERR_UNHANDLED_ERROR]: Unhandled error. ({ Error: socket hang up
    at InterceptedRequestHandler.handleAbort (/Users/mcarballal/Projects/fashion-store-api/node_modules/nock/lib/request_overrider.js:230:28)
    at OverriddenClientRequest.req.abort.args [as abort] (/Users/mcarballal/Projects/fashion-store-api/node_modules/nock/lib/request_overrider.js:129:35)
    at Timeout.setTimeout (/Users/mcarballal/Projects/fashion-store-api/node_modules/perron/lib/request.ts:353:10)
    at ontimeout (timers.js:436:11)
    at tryOnTimeout (timers.js:300:5)
    at listOnTimeout (timers.js:263:5)
    at Timer.processTimers (timers.js:223:10) code: 'ECONNRESET' })
    at OverriddenClientRequest.emit (events.js:187:17)
    at OverriddenClientRequest.EventEmitter.emit (domain.js:448:20)
    at /Users/mcarballal/Projects/fashion-store-api/node_modules/nock/lib/request_overrider.js:238:11
    at process._tickCallback (internal/process/next_tick.js:61:11)
````