### PR TITLE
Update filter type to allow synchronous filters

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -50,14 +50,17 @@ export interface ServiceClientRequestFilter {
    */
   request?: (
     requestOptions: ServiceClientRequestOptions
-  ) => Promise<ServiceClientResponse | ServiceClientRequestOptions>;
+  ) =>
+    | ServiceClientResponse
+    | ServiceClientRequestOptions
+    | Promise<ServiceClientResponse | ServiceClientRequestOptions>;
   /**
    * This callback is called after the response has arrived.
    * @throws {Error}
    */
   response?: (
     response: ServiceClientResponse
-  ) => Promise<ServiceClientResponse>;
+  ) => ServiceClientResponse | Promise<ServiceClientResponse>;
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "perron",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1519,7 +1519,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "perron",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "A sane client for web services",
   "engines": {
     "node": ">=8.0.0"


### PR DESCRIPTION
Updating `ServiceClientRequestFilter` type to allow synchronous filter methods. In the implementation, they can return a non-promise value as written in README and tested in the unit tests.