### PR TITLE
Target node12 in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es2015",
+    "target": "es2019",
     "noImplicitAny": true,
     "moduleResolution": "node",
     "sourceMap": true,
@@ -11,7 +11,7 @@
     "outDir": "./dist",
     "rootDir": "./lib",
     "lib": [
-      "es2018"
+      "es2020"
     ],
     "typeRoots": ["./types", "./node_modules/@types"]
   }


### PR DESCRIPTION
Since the lowest supported node version was raised to 12, we can also
bump the compile target to es2019. Ref.
https://stackoverflow.com/questions/59787574/typescript-tsconfig-settings-for-node-js-12/59787575#59787575